### PR TITLE
Feat/calldata compression

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/everest-chainlink-consumer"]
 	path = lib/everest-chainlink-consumer
 	url = https://github.com/palmcivet7/everest-chainlink-consumer
+[submodule "lib/solady"]
+	path = lib/solady
+	url = https://github.com/vectorized/solady

--- a/certora/conf/Compliant.conf
+++ b/certora/conf/Compliant.conf
@@ -6,6 +6,7 @@
        "./test/mocks/MockAutomationRegistry.sol",
        "./test/mocks/MockForwarder.sol",
        "./test/mocks/MockEverestConsumer.sol",
+       "lib/solady/src/utils/LibZip.sol",
     ],
     "verify": "Harness:./certora/spec/Compliant.spec",
     "wait_for_results": "all",
@@ -24,5 +25,4 @@
         "MockEverestConsumer:i_link=ERC677",
     ],
     "parametric_contracts": "Harness",
-
 }

--- a/certora/harness/Harness.sol
+++ b/certora/harness/Harness.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.24;
 
 import {Compliant} from "../../src/Compliant.sol";
 import {IEverestConsumer} from "lib/everest-chainlink-consumer/contracts/EverestConsumer.sol";
+import {LibZip} from "@solady/src/utils/LibZip.sol";
 
 contract Harness is Compliant {
     /*//////////////////////////////////////////////////////////////
@@ -30,4 +31,12 @@ contract Harness is Compliant {
         bytes32 requestId = bytes32(uint256(uint160(user)));
         return abi.encode(requestId, user, isCompliant);
     }
+
+    // function compress(bytes memory data) external returns (bytes memory) {
+    //     return LibZip.cdCompress(data);
+    // }
+
+    // function decompress(bytes memory data) external returns (bytes memory) {
+    //     return LibZip.cdDecompress(data);
+    // }
 }

--- a/certora/harness/Harness.sol
+++ b/certora/harness/Harness.sol
@@ -31,12 +31,4 @@ contract Harness is Compliant {
         bytes32 requestId = bytes32(uint256(uint160(user)));
         return abi.encode(requestId, user, isCompliant);
     }
-
-    // function compress(bytes memory data) external returns (bytes memory) {
-    //     return LibZip.cdCompress(data);
-    // }
-
-    // function decompress(bytes memory data) external returns (bytes memory) {
-    //     return LibZip.cdDecompress(data);
-    // }
 }

--- a/certora/spec/Compliant.spec
+++ b/certora/spec/Compliant.spec
@@ -33,20 +33,12 @@ methods {
     function isAutomation(address,bytes) external returns (bytes) envfree;
     function noAutomation(address,bytes) external returns (bytes) envfree;
     function performData(address,bool) external returns (bytes) envfree;
+    // function compress(bytes) external returns (bytes) envfree;
+    // function decompress(bytes) external returns (bytes) envfree;
 
     // LibZip summaries
-    function _.cdCompress(bytes memory input) internal => 
-        cvlCdCompress(input) expect (bytes memory);
-    function _.cdDecompress(bytes memory input) internal => 
-        cvlCdDecompress(input) expect (bytes memory);
-}
-
-function cvlCdCompress(bytes data) returns bytes {
-    return data;
-}
-
-function cvlCdDecompress(bytes data) returns bytes {
-    return data;
+    function _.cdCompress(bytes memory data) internal => compressionSummary(data) expect (bytes memory);
+    function _.cdDecompress(bytes memory data) internal => compressionSummary(data) expect (bytes memory);
 }
 
 /*//////////////////////////////////////////////////////////////
@@ -75,6 +67,24 @@ definition KYCStatusRequestFulfilledEvent() returns bytes32 =
 definition CompliantCheckPassedEvent() returns bytes32 =
 // keccak256(abi.encodePacked("CompliantCheckPassed()"))
     to_bytes32(0x55c497259911f7217100faf4dee7dc3263e9067bc83617fa439721b7047574de);
+
+/*//////////////////////////////////////////////////////////////
+                           FUNCTIONS
+//////////////////////////////////////////////////////////////*/
+/// @notice summarize LibZip.cdCompress() and LibZip.cdDecompress()
+/// @notice we are not verifying the LibZip library so are ok with such a basic mock
+// review - should we be asserting if isPending && data != 0, {PendingRequest.compliantCalldata == compressed(data)} ?
+function compressionSummary(bytes data) returns bytes {
+    return data;
+}
+
+// function cdCompressSummary(bytes data) returns bytes {
+//     return compress(data);
+// }
+
+// function cdDecompressSummary(bytes data) returns bytes {
+//     return decompress(data);
+// }
 
 /*//////////////////////////////////////////////////////////////
                              GHOSTS
@@ -124,6 +134,7 @@ ghost bool g_fulfilledRequestIsCompliant {
     init_state axiom g_fulfilledRequestIsCompliant == false;
 }
 
+// review - unused ghost
 persistent ghost mapping(address => bool) g_fulfilledRequestStatus {
     init_state axiom forall address a. g_fulfilledRequestStatus[a] == false;
 }
@@ -457,7 +468,7 @@ rule requestKycStatus_compliantCalldata_storedCorrectly() {
 
     Compliant.PendingRequest request_after = getPendingRequest(user);
 
-    assert request_after.compliantCalldata == arbitraryData => request_after.isPending;
+    assert request_after.compliantCalldata == compressionSummary(arbitraryData) => request_after.isPending;
     assert !request_after.isPending => request_after.compliantCalldata.length == 0;
 }
 
@@ -477,7 +488,7 @@ rule onTokenTransfer_compliantCalldata_storedCorrectly() {
 
     Compliant.PendingRequest request_after = getPendingRequest(user);
 
-    assert request_after.compliantCalldata == arbitraryData => request_after.isPending;
+    assert request_after.compliantCalldata == compressionSummary(arbitraryData) => request_after.isPending;
     assert !request_after.isPending => request_after.compliantCalldata.length == 0;
 }
 

--- a/certora/spec/Compliant.spec
+++ b/certora/spec/Compliant.spec
@@ -33,6 +33,20 @@ methods {
     function isAutomation(address,bytes) external returns (bytes) envfree;
     function noAutomation(address,bytes) external returns (bytes) envfree;
     function performData(address,bool) external returns (bytes) envfree;
+
+    // LibZip summaries
+    function _.cdCompress(bytes memory input) internal => 
+        cvlCdCompress(input) expect (bytes memory);
+    function _.cdDecompress(bytes memory input) internal => 
+        cvlCdDecompress(input) expect (bytes memory);
+}
+
+function cvlCdCompress(bytes data) returns bytes {
+    return data;
+}
+
+function cvlCdDecompress(bytes data) returns bytes {
+    return data;
 }
 
 /*//////////////////////////////////////////////////////////////

--- a/certora/spec/Compliant.spec
+++ b/certora/spec/Compliant.spec
@@ -33,8 +33,6 @@ methods {
     function isAutomation(address,bytes) external returns (bytes) envfree;
     function noAutomation(address,bytes) external returns (bytes) envfree;
     function performData(address,bool) external returns (bytes) envfree;
-    // function compress(bytes) external returns (bytes) envfree;
-    // function decompress(bytes) external returns (bytes) envfree;
 
     // LibZip summaries
     function _.cdCompress(bytes memory data) internal => compressionSummary(data) expect (bytes memory);
@@ -73,18 +71,10 @@ definition CompliantCheckPassedEvent() returns bytes32 =
 //////////////////////////////////////////////////////////////*/
 /// @notice summarize LibZip.cdCompress() and LibZip.cdDecompress()
 /// @notice we are not verifying the LibZip library so are ok with such a basic mock
-// review - should we be asserting if isPending && data != 0, {PendingRequest.compliantCalldata == compressed(data)} ?
+// review - if isPending && data != 0, {PendingRequest.compliantCalldata == compressed(data)}
 function compressionSummary(bytes data) returns bytes {
     return data;
 }
-
-// function cdCompressSummary(bytes data) returns bytes {
-//     return compress(data);
-// }
-
-// function cdDecompressSummary(bytes data) returns bytes {
-//     return decompress(data);
-// }
 
 /*//////////////////////////////////////////////////////////////
                              GHOSTS

--- a/remappings.txt
+++ b/remappings.txt
@@ -2,3 +2,4 @@
 @chainlink/contracts/=lib/chainlink/contracts/
 @openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
 @openzeppelin/contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/
+@solady/src/=lib/solady/src/

--- a/src/Compliant.sol
+++ b/src/Compliant.sol
@@ -12,6 +12,7 @@ import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/shared/interf
 import {IERC677Receiver} from "@chainlink/contracts/src/v0.8/shared/interfaces/IERC677Receiver.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {LibZip} from "@solady/src/utils/LibZip.sol";
 
 /// @notice A template contract for requesting and getting the KYC compliant status of an address.
 contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC677Receiver {
@@ -19,6 +20,7 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
                            TYPE DECLARATIONS
     //////////////////////////////////////////////////////////////*/
     using SafeERC20 for LinkTokenInterface;
+    using LibZip for bytes;
 
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
@@ -126,14 +128,21 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
     /// @param data encoded data should contain the user address to request the kyc status of, a boolean
     /// indicating whether automation should be used to subsequently execute logic based on the immediate result,
     /// and arbitrary data to be passed to compliant restricted logic
-    function onTokenTransfer(address, /*sender */ uint256 amount, bytes calldata data) external onlyProxy {
+    function onTokenTransfer(
+        address,
+        /* sender */
+        uint256 amount,
+        bytes calldata data
+    ) external onlyProxy {
         if (msg.sender != address(i_link)) revert Compliant__OnlyLinkToken();
 
         (address user, bool isAutomatedRequest, bytes memory compliantCalldata) =
             abi.decode(data, (address, bool, bytes));
 
         uint256 fees = _handleFees(isAutomatedRequest, true);
-        if (amount < fees) revert Compliant__InsufficientLinkTransferAmount(fees);
+        if (amount < fees) {
+            revert Compliant__InsufficientLinkTransferAmount(fees);
+        }
 
         _requestKycStatus(user, isAutomatedRequest, compliantCalldata);
     }
@@ -181,13 +190,17 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
 
             /// @dev revert if request wasn't made by this contract
             address revealer = address(uint160(uint256(log.topics[2])));
-            if (revealer != address(this)) revert Compliant__RequestNotMadeByThisContract();
+            if (revealer != address(this)) {
+                revert Compliant__RequestNotMadeByThisContract();
+            }
 
             (address requestedAddress, IEverestConsumer.Status kycStatus,) =
                 abi.decode(log.data, (address, IEverestConsumer.Status, uint40));
 
             bool isCompliant;
-            if (kycStatus == IEverestConsumer.Status.KYCUser) isCompliant = true;
+            if (kycStatus == IEverestConsumer.Status.KYCUser) {
+                isCompliant = true;
+            }
 
             if (s_pendingRequests[requestedAddress].isPending) {
                 performData = abi.encode(requestId, requestedAddress, isCompliant);
@@ -200,7 +213,9 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
     /// @dev this function should contain the logic restricted for compliant only users
     /// @param performData encoded bytes contains bytes32 requestId, address of requested user and bool isCompliant
     function performUpkeep(bytes calldata performData) external onlyProxy {
-        if (msg.sender != address(i_forwarder)) revert Compliant__OnlyForwarder();
+        if (msg.sender != address(i_forwarder)) {
+            revert Compliant__OnlyForwarder();
+        }
         (bytes32 requestId, address user, bool isCompliant) = abi.decode(performData, (bytes32, address, bool));
 
         s_pendingRequests[user].isPending = false;
@@ -209,6 +224,8 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
         /// @dev reset compliantCalldata mapped to user
         if (data.length > 0) {
             s_pendingRequests[user].compliantCalldata = "";
+            // decompress data
+            // data = decompressedData
         }
 
         emit KYCStatusRequestFulfilled(requestId, user, isCompliant);
@@ -256,7 +273,9 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
 
     /// @dev Chainlink Automation will only trigger for a true pending request
     function _setPendingRequest(address user, bytes memory compliantCalldata) internal {
-        if (s_pendingRequests[user].isPending) revert Compliant__PendingRequestExists(user);
+        if (s_pendingRequests[user].isPending) {
+            revert Compliant__PendingRequestExists(user);
+        }
         s_pendingRequests[user].isPending = true;
 
         if (compliantCalldata.length > 0) {

--- a/src/Compliant.sol
+++ b/src/Compliant.sol
@@ -224,8 +224,8 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
         /// @dev reset compliantCalldata mapped to user
         if (data.length > 0) {
             s_pendingRequests[user].compliantCalldata = "";
-            // decompress data
-            // data = decompressedData
+            /// @dev decompress the data with LibZip
+            data = data.cdDecompress();
         }
 
         emit KYCStatusRequestFulfilled(requestId, user, isCompliant);
@@ -279,7 +279,9 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
         s_pendingRequests[user].isPending = true;
 
         if (compliantCalldata.length > 0) {
-            s_pendingRequests[user].compliantCalldata = compliantCalldata;
+            /// @dev compress the data with LibZip before storing it
+            bytes memory compressedData = compliantCalldata.cdCompress();
+            s_pendingRequests[user].compliantCalldata = compressedData;
         }
     }
 

--- a/src/Compliant.sol
+++ b/src/Compliant.sol
@@ -225,7 +225,8 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
         if (data.length > 0) {
             s_pendingRequests[user].compliantCalldata = "";
             /// @dev decompress the data with LibZip
-            data = data.cdDecompress();
+            // data = data.cdDecompress();
+            data = LibZip.cdDecompress(data);
         }
 
         emit KYCStatusRequestFulfilled(requestId, user, isCompliant);
@@ -280,7 +281,8 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
 
         if (compliantCalldata.length > 0) {
             /// @dev compress the data with LibZip before storing it
-            bytes memory compressedData = compliantCalldata.cdCompress();
+            // bytes memory compressedData = compliantCalldata.cdCompress();
+            bytes memory compressedData = LibZip.cdCompress(compliantCalldata);
             s_pendingRequests[user].compliantCalldata = compressedData;
         }
     }

--- a/src/Compliant.sol
+++ b/src/Compliant.sol
@@ -280,6 +280,7 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
 
         if (compliantCalldata.length > 0) {
             /// @dev compress the data with LibZip before storing it
+            // review do we want to skip compression to save gas, and assume end user compressed it themselves?
             bytes memory compressedData = compliantCalldata.cdCompress();
             s_pendingRequests[user].compliantCalldata = compressedData;
         }

--- a/src/Compliant.sol
+++ b/src/Compliant.sol
@@ -225,8 +225,7 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
         if (data.length > 0) {
             s_pendingRequests[user].compliantCalldata = "";
             /// @dev decompress the data with LibZip
-            // data = data.cdDecompress();
-            data = LibZip.cdDecompress(data);
+            data = data.cdDecompress();
         }
 
         emit KYCStatusRequestFulfilled(requestId, user, isCompliant);
@@ -281,8 +280,7 @@ contract Compliant is ILogAutomation, AutomationBase, OwnableUpgradeable, IERC67
 
         if (compliantCalldata.length > 0) {
             /// @dev compress the data with LibZip before storing it
-            // bytes memory compressedData = compliantCalldata.cdCompress();
-            bytes memory compressedData = LibZip.cdCompress(compliantCalldata);
+            bytes memory compressedData = compliantCalldata.cdCompress();
             s_pendingRequests[user].compliantCalldata = compressedData;
         }
     }

--- a/test/invariant/Handler.t.sol
+++ b/test/invariant/Handler.t.sol
@@ -10,6 +10,7 @@ import {LinkTokenInterface} from "@chainlink/contracts/src/v0.8/shared/interface
 import {IEverestConsumer} from "@everest/contracts/interfaces/IEverestConsumer.sol";
 import {IAutomationRegistryConsumer} from
     "@chainlink/contracts/src/v0.8/automation/interfaces/IAutomationRegistryConsumer.sol";
+import {LibZip} from "@solady/src/utils/LibZip.sol";
 
 contract Handler is Test {
     /*//////////////////////////////////////////////////////////////
@@ -312,7 +313,8 @@ contract Handler is Test {
     function _updateRequestGhosts(address user, bool isAutomation, bytes memory compliantCalldata) internal {
         /// @dev store compliantCalldata in ghost mapping
         if (isAutomation && compliantCalldata.length > 0) {
-            g_requestedAddressToCalldata[user] = compliantCalldata;
+            bytes memory compressedData = LibZip.cdCompress(compliantCalldata);
+            g_requestedAddressToCalldata[user] = compressedData;
         }
 
         /// @dev set request to pending

--- a/test/unit/OnTokenTransfer.t.sol
+++ b/test/unit/OnTokenTransfer.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.24;
 
 import {BaseTest, Vm, LinkTokenInterface, Compliant, console2} from "../BaseTest.t.sol";
 import {MockLinkToken} from "../mocks/MockLinkToken.sol";
+import {LibZip} from "@solady/src/utils/LibZip.sol";
 
 contract OnTokenTransferTest is BaseTest {
     function test_compliant_onTokenTransfer_noAutomation() public {
@@ -68,8 +69,11 @@ contract OnTokenTransferTest is BaseTest {
         bool isPending = pendingRequest.isPending;
         bytes memory storedCalldata = pendingRequest.compliantCalldata;
 
+        /// @dev decompress storedCalldata
+        bytes memory decompressedData = LibZip.cdDecompress(storedCalldata);
+
         assertTrue(isPending);
-        assertEq(storedCalldata, compliantCalldata);
+        assertEq(decompressedData, compliantCalldata);
         assertEq(emittedRequestId, expectedRequestId);
         assertEq(user, emittedUser);
     }

--- a/test/unit/RequestKycStatus.t.sol
+++ b/test/unit/RequestKycStatus.t.sol
@@ -59,6 +59,7 @@ contract RequestKycStatusTest is BaseTest {
         bytes memory compliantCalldata = abi.encode(1);
 
         uint256 expectedFee = compliant.getFeeWithAutomation();
+
         /// @dev call requestKycStatus
         uint256 actualFee = _requestKycStatus(user, expectedFee, user, true, compliantCalldata);
 
@@ -152,6 +153,7 @@ contract RequestKycStatusTest is BaseTest {
             )
         );
         uint256 actualFee = abi.decode(retData, (uint256));
+
         return actualFee;
     }
 }

--- a/test/unit/RequestKycStatus.t.sol
+++ b/test/unit/RequestKycStatus.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.24;
 
 import {BaseTest, Vm, LinkTokenInterface, Compliant, console2} from "../BaseTest.t.sol";
+import {LibZip} from "@solady/src/utils/LibZip.sol";
 
 /// review these tests - can be refactored further to improve modularity/readability
 contract RequestKycStatusTest is BaseTest {
@@ -84,7 +85,8 @@ contract RequestKycStatusTest is BaseTest {
         bytes memory storedCalldata = pendingRequest.compliantCalldata;
 
         assertTrue(isPending);
-        assertEq(storedCalldata, compliantCalldata);
+        /// @dev decompress storedCalldata
+        assertEq(LibZip.cdDecompress(storedCalldata), compliantCalldata);
         assertEq(linkBalanceAfter + expectedFee, linkBalanceBefore);
         assertEq(emittedRequestId, expectedRequestId);
         assertEq(user, emittedUser);


### PR DESCRIPTION
Arbitrary data passed to compliant restricted logic gets compressed before written to storage and decompressed when used. Compression/decompression is done with solady's LibZip. This is done to save on storage costs.